### PR TITLE
Fix Too Many Arguments Errors

### DIFF
--- a/.github/workflows/pr-from-issue.yml
+++ b/.github/workflows/pr-from-issue.yml
@@ -40,16 +40,10 @@ jobs:
       - id: modify-mod-list
         uses: ./modify-mod-list
         with:
+          out-file: mods.json
           github-token: ${{ secrets.GH_TOKEN }}
           form: "${{ steps.issue-parser.outputs.jsonString }}"
           mods: "${{ steps.local-mods.outputs.mods }}"
-
-      - name: Write mods list to file
-        uses: DamianReeves/write-file-action@v1.0
-        with:
-          path: mods.json
-          contents: "${{ steps.modify-mod-list.outputs.mods }}"
-          write-mode: overwrite
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/update-releases.yml
+++ b/.github/workflows/update-releases.yml
@@ -45,6 +45,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN  }}
           discord-mod-hook-urls: ${{ secrets.DISCORD_MOD_HOOK_URLS }}
           mods: "${{ steps.local-mods.outputs.mods }}"
+          out-file: "database.json"
           discord-hook-url: "${{ secrets.DISCORD_HOOK_URL }}"
           discord-mod-update-role-id: "${{ secrets.DISCORD_MOD_UPDATE_ROLE_ID }}"
           discord-new-mod-role-id: "${{ secrets.DISCORD_NEW_MOD_ROLE_ID }}"
@@ -53,12 +54,6 @@ jobs:
         with:
           ref: "master"
           fetch-depth: 0
-      - name: Write database to file
-        uses: DamianReeves/write-file-action@v1.0
-        with:
-          path: database.json
-          contents: "${{ steps.fetch-mods.outputs.releases }}"
-          write-mode: overwrite
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v4.1.6
         with:

--- a/.github/workflows/upload-pr-artifact.yml
+++ b/.github/workflows/upload-pr-artifact.yml
@@ -42,16 +42,10 @@ jobs:
         id: fetch-mods
         uses: ./fetch-mods
         with:
+          out-file: database.json
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN  }}
           mods: "${{ steps.local-mods.outputs.mods }}"
           google-service-account: "${{ secrets.GOOGLE_SERVICE_ACCOUNT }}"
-
-      - name: Write database to file
-        uses: DamianReeves/write-file-action@v1.0
-        with:
-          path: database.json
-          contents: "${{ steps.fetch-mods.outputs.releases }}"
-          write-mode: overwrite
 
       - uses: actions/upload-artifact@v2
         with:

--- a/fetch-mods/action.yml
+++ b/fetch-mods/action.yml
@@ -1,6 +1,9 @@
 name: "Get mods"
 description: "Gets mod releases"
 inputs:
+  out-file:
+      description: "Optional JSON file path to write to"
+      required: false
   mods:
     description: "JSON list of mods to check"
     required: true

--- a/fetch-mods/index.ts
+++ b/fetch-mods/index.ts
@@ -7,7 +7,7 @@ import { fetchModManager } from "./fetch-mod-manager";
 import { toJsonString } from "./to-json-string";
 import { getViewCounts } from "./get-view-counts";
 
-const fs = require("fs");
+import { writeFile } from "fs";
 
 enum Input {
   outFile = "out-file",
@@ -60,7 +60,7 @@ async function run() {
     const outputFilePath = core.getInput(Input.outFile);
 
     if (outputFilePath) {
-      fs.writeFile(outputFilePath, databaseJson, (error) => { console.log("Error Saving To File:", error) });
+      writeFile(outputFilePath, databaseJson, (error) => { console.log("Error Saving To File:", error) });
     }
 
     const discordHookUrl = core.getInput(Input.discordHookUrl);

--- a/fetch-mods/index.ts
+++ b/fetch-mods/index.ts
@@ -60,7 +60,7 @@ async function run() {
     const outputFilePath = core.getInput(Input.outFile);
 
     if (outputFilePath) {
-      fs.writeFile(outputFilePath, databaseJson);
+      fs.writeFile(outputFilePath, databaseJson, (error) => { console.log("Error Saving To File:", error) });
     }
 
     const discordHookUrl = core.getInput(Input.discordHookUrl);

--- a/fetch-mods/index.ts
+++ b/fetch-mods/index.ts
@@ -60,7 +60,7 @@ async function run() {
     const outputFilePath = core.getInput(Input.outFile);
 
     if (outputFilePath) {
-      writeFile(outputFilePath, databaseJson, (error) => { console.log("Error Saving To File:", error) });
+      writeFile(outputFilePath, databaseJson, (error) => { if (error) console.log("Error Saving To File:", error) });
     }
 
     const discordHookUrl = core.getInput(Input.discordHookUrl);

--- a/fetch-mods/index.ts
+++ b/fetch-mods/index.ts
@@ -7,7 +7,10 @@ import { fetchModManager } from "./fetch-mod-manager";
 import { toJsonString } from "./to-json-string";
 import { getViewCounts } from "./get-view-counts";
 
+const fs = require("fs");
+
 enum Input {
+  outFile = "out-file",
   mods = "mods",
   discordHookUrl = "discord-hook-url",
   discordModUpdateRoleId = "discord-mod-update-role-id",
@@ -53,6 +56,12 @@ async function run() {
       alphaReleases: modListWithViewCounts.filter(({ alpha }) => alpha),
     });
     core.setOutput(Output.releases, databaseJson);
+
+    const outputFilePath = core.getInput(Input.outFile);
+
+    if (outputFilePath) {
+      fs.writeFile(outputFilePath, databaseJson);
+    }
 
     const discordHookUrl = core.getInput(Input.discordHookUrl);
 

--- a/modify-mod-list/action.yml
+++ b/modify-mod-list/action.yml
@@ -1,6 +1,9 @@
 name: "Modify mod list"
 description: "Modifies the mod list based on a mod submission issue"
 inputs:
+  out-file:
+      description: "Optional JSON file path to write to"
+      required: false
   github-token:
     description: "Token for GitHub authentication"
     required: true

--- a/modify-mod-list/index.ts
+++ b/modify-mod-list/index.ts
@@ -1,6 +1,9 @@
 import * as core from "@actions/core";
 
+import { writeFile } from "fs";
+
 enum Input {
+  outFile = "out-file",
   form = "form",
   mods = "mods",
   gitHubToken = "github-token",
@@ -94,7 +97,16 @@ async function run() {
 
   const newMods: ModInfo[] = existingMod ? mods : [...mods, newMod];
 
-  core.setOutput(Output.mods, JSON.stringify(newMods, null, 2));
+  const jsonString = JSON.stringify(newMods, null, 2);
+
+  core.setOutput(Output.mods, jsonString);
+
+  const outFile = core.getInput(Input.outFile);
+
+  if (outFile) {
+    writeFile(outFile, jsonString, (error) => { if (error) console.log("Couldn't Write To Mods File: ", error) });
+  }
+
   if (existingMod) {
     core.setOutput(Output.editedExistingMod, true);
   }


### PR DESCRIPTION
With the newest PRs to this repo, we're experiencing an issue where the database file is too long to be passed to the node runtime as an argument. This PR changes it so the custom actions we have in this repo automatically write to the file instead of using another step in the workflow.  This also does this for generating the `mods.json` just so we won't experience the same issue with that.