### PR TITLE
Don't remove schema in generated PR

### DIFF
--- a/fetch-mods/globals.d.ts
+++ b/fetch-mods/globals.d.ts
@@ -1,4 +1,5 @@
 type ModDB = {
+  $schema: string
   mods: ModInfo[];
 };
 

--- a/modify-mod-list/index.ts
+++ b/modify-mod-list/index.ts
@@ -16,6 +16,7 @@ enum Output {
 
 // Mod db from mods.json.
 type ModDB = {
+  $schema: string
   mods: ModInfo[];
 };
 
@@ -110,6 +111,7 @@ async function run() {
   }
 
   const newModDb: ModDB = {
+    $schema: "./mods.schema.json",
     mods: existingMod ? mods : [...mods, newMod],
   };
 


### PR DESCRIPTION
PRs generated from add-mod issues remove the $schema added to mods.json in #456.
Example: https://github.com/ow-mods/ow-mod-db/pull/466/files#diff-d0f1634e0f0cf330864a5baae3fc77e2d56cc941dd9796830dc63638d91da86fL2

So this PR fixed that and now the generated PR also serializes the $schema field.

Before: https://github.com/dgarroDC/ow-mod-db/pull/2/files
After: https://github.com/dgarroDC/ow-mod-db/pull/3/files