### PR TITLE
Fix notifications with long changelogs not being sent

### DIFF
--- a/scripts/src/send-notifications/send-discord-notifications.ts
+++ b/scripts/src/send-notifications/send-discord-notifications.ts
@@ -35,6 +35,29 @@ function getNotificationDescription({ diffType, nextMod }: DiffItem) {
     }
   }
 
+  const maxLength = 1000; // Not sure if this is documented somewhere, I found this experimentally (cap is somewhere between 1000 and 1050)
+  const truncatedDisclaimer = '**...**\n\n**Check the mod repo for the complete changelog.**';
+  const endPosition = maxLength - 1 - truncatedDisclaimer.length;
+
+  if (description && description.length > maxLength) {
+    description = description.slice(0, endPosition);
+    // Don't slice in the middle of a word
+    let lastIndex = description.lastIndexOf(" ");
+    if (description[lastIndex-1].match(/^[.,:!?]/)) {
+      lastIndex--;
+    }
+    description = description.slice(0, lastIndex);
+    // Try to respect markdown links in the form [text text text](website.something.whatever)
+    // Because we only slice at spaces we just have to check if we're inside square brackets
+    let openSquareBracket = description.lastIndexOf("[");
+    let closeSquareBracket = description.lastIndexOf("]");
+    if (openSquareBracket != -1 && (closeSquareBracket == -1 || closeSquareBracket < openSquareBracket)) 
+    {
+      description = description.slice(0, openSquareBracket);
+    }
+    description += truncatedDisclaimer;
+  }
+
   return (
     description ||
     `Mod tagged as ${

--- a/scripts/src/send-notifications/send-discord-notifications.ts
+++ b/scripts/src/send-notifications/send-discord-notifications.ts
@@ -35,7 +35,7 @@ function getNotificationDescription({ diffType, nextMod }: DiffItem) {
     }
   }
 
-  const maxLength = 1000; // Not sure if this is documented somewhere, I found this experimentally (cap is somewhere between 1000 and 1050)
+  const maxLength = 4000; // Max length of a Discord embed description is 4096, have to leave room for the title though.
   const truncatedDisclaimer = '**...**\n\n**Check the mod repo for the complete changelog.**';
   const endPosition = maxLength - 1 - truncatedDisclaimer.length;
 
@@ -98,11 +98,8 @@ function getEmbed(diffItem: DiffItem) {
   return {
     type: "rich",
     title: diffItem.nextMod.name,
+    description: `${getNotificationTitle(diffItem)}\n>>> ${description}`,
     fields: [
-      {
-        name: getNotificationTitle(diffItem),
-        value: description ? `>>> ${description}` : "\u200B",
-      },
       {
         name: "\u200B",
         value: `<:github:1085179483784499260> [Source Code](${diffItem.nextMod.repo})`,

--- a/scripts/src/test/test.ts
+++ b/scripts/src/test/test.ts
@@ -6,6 +6,9 @@ import { getDiff } from "../send-notifications/get-diff.js";
 import { sendDiscordNotifications } from "../send-notifications/send-discord-notifications.js";
 
 async function test() {
+  const now = new Date().toISOString();
+  console.log("Now: " + now);
+
   const mod: BaseMod = {
     name: "NomaiVR",
     uniqueName: "Raicuparta.NomaiVR",
@@ -26,35 +29,40 @@ async function test() {
     thumbnail: {
       main: "nomaivr-static.webp",
     },
-    latestReleaseDescription: `- Stereoscopic view in post credits sequence
-    - Input prompts are now unaffected by the texture resolution setting
-    - Additional settings for flashlight gesture, look arrow and markers opacity
-    - Disable walking when holding a tool or when concealing the lantern`,
+    latestReleaseDescription: "For installation instructions [see the README](https://github.com/Ixrec/OuterWildsArchipelagoRandomizer#installation).\r\n\r\n- **Logsanity**: Added a `logsanity` option (`false` by default) that adds **176 more locations** for all the (non-DLC, non-rumor, non-missable) ship log facts in the game. (Thanks @hopop201 for help checking these location names for spoilers)\r\n- Various bugfixes, tweaks and internal code cleanups. The ones noticeable to players are:\r\n  - Previously, receiving a non-unique filler item (marshmallow, oxygen refill, fuel refill) after switching profiles would have no effect. This should be fixed now.\r\n  - Reaching Feldspar via Signalscope is now in logic. Previously there was a bug causing only the Scout method to be in logic.\r\n  - When you connect to a multiworld made with a different .apworld version from the mod version, the warning message now appears in the in-game console without having to pause first, so it should be harder to miss\r\n  - When the mod tries to check a location but the AP server times out, it now prints a warning to the in-game console (not just the OWML logs), so it's easier to tell there's a connection issue beyond the mod's control\r\n- Additional tweaks since the Release Candidate:\r\n  - The logsanity location \"ET Ship Log: Sunless City 3 - Signal\" now correctly requires Ghost Matter Wavelength\r\n  - Made mid-game communication with the AP server non-blocking. That means the game will no longer freeze for up to 2 seconds whenever it tries to tell the AP server you checked a location (this is usually only noticeable if the server is down).\r\n  - Rewrote README instructions for installing old or prerelease versions of the mod now that I've become aware of and tested more Outer Wilds Mod Manager features.",
   };
 
+  const otherMod: BaseMod = {
+    name: "Among Us - The Musical",
+    uniqueName: "Raicuparta.Joe",
+    slug: "amongusthemusical",
+    description:
+      "The best mod ever made",
+    author: "Paicuparta",
+    authorDisplay: "Paicuparta",
+    repo: "https://github.com/Raicuparta/nomai-vr",
+    latestReleaseDate: "latestReleaseDate",
+    firstReleaseDate: "firstReleaseDate",
+    repoUpdatedAt: "repoUpdatedAt",
+    databaseEntryUpdatedAt: "databaseEntryUpdatedAt",
+    downloadUrl: "downloadUrl",
+    downloadCount: 0,
+    version: "0.0.1",
+    tags: [],
+    thumbnail: {
+      main: "newhorizons.webp",
+    },
+    latestReleaseDescription: "For installation instructions [see the README](https://github.com/Ixrec/OuterWildsArchipelagoRandomizer#installation).\r\n\r\n- **Logsanity**: Added a `logsanity` option (`false` by default) that adds **176 more locations** for all the (non-DLC, non-rumor, non-missable) ship log facts in the game. (Thanks @hopop201 for help checking these location names for spoilers)\r\n- Various bugfixes, tweaks and internal code cleanups. The ones noticeable to players are:\r\n  - Previously, receiving a non-unique filler item (marshmallow, oxygen refill, fuel refill) after switching profiles would have no effect. This should be fixed now.\r\n  - Reaching Feldspar via Signalscope is now in logic. Previously there was a bug causing only the Scout method to be in logic.\r\n  - When you connect to a multiworld made with a different .apworld version from the mod version, the warning message now appears in the in-game console without having to pause first, so it should be harder to miss\r\n  - When the mod tries to check a location but the AP server times out, it now prints a warning to the in-game console (not just the OWML logs), so it's easier to tell there's a connection issue beyond the mod's control\r\n- Additional tweaks since the Release Candidate:\r\n  - The logsanity location \"ET Ship Log: Sunless City 3 - Signal\" now correctly requires Ghost Matter Wavelength\r\n  - Made mid-game communication with the AP server non-blocking. That means the game will no longer freeze for up to 2 seconds whenever it tries to tell the AP server you checked a location (this is usually only noticeable if the server is down).\r\n  - Rewrote README instructions for installing old or prerelease versions of the mod now that I've become aware of and tested more Outer Wilds Mod Manager features.",
+  };
+
+  const mod2 = { ...mod, version: "0.0.2", latestReleaseDate: now };
+  const otherMod2 = { ...otherMod, version: "0.0.2", latestReleaseDate: now };
+
   const diff = getDiff(
-    [mod],
-    [
-      { ...mod, version: "0.0.2" },
-      {
-        ...mod,
-        description: "",
-        parent: "daddy",
-        tags: ["funny"],
-        prerelease: {
-          version: "0.0.3",
-          downloadUrl: "https://haha",
-          date: "",
-        },
-      },
-      {
-        ...mod,
-        parent: "daddy",
-        uniqueName: "Raicuparta.NomaiVR2",
-        slug: "nomaivr2",
-      },
-    ]
+    [mod, otherMod],
+    [mod2, otherMod2]
   );
+
   sendDiscordNotifications(secrets.discordHookUrl, "", "", diff, {});
 
   // fetchMods(JSON.stringify(modsJson), "output", []);


### PR DESCRIPTION
Embed description field can store 4096 characters while the embed fields could only store 1024.

Also if the text goes over that limit it will now be truncated.